### PR TITLE
Ensure that equality on unicode chars works.

### DIFF
--- a/equal.go
+++ b/equal.go
@@ -317,18 +317,24 @@ func (t *T) deepEqual(
 		// and assert to a string will panic.
 		hstr := have.String()
 		wstr := want.String()
-		if len(hstr) != len(wstr) {
+		if hstr == wstr {
+			// Cheap equality test passed, no need to continue.
+			break
+		}
+		hrunes := []rune(hstr)
+		wrunes := []rune(wstr)
+		if len(hrunes) != len(wrunes) {
 			return []string{
 				fmt.Sprintf("%s: len(have) %d != len(want) %d.",
-					desc, len(hstr), len(wstr)),
+					desc, len(hrunes), len(wrunes)),
 				fmt.Sprintf("  have: %#v", hstr),
 				fmt.Sprintf("  want: %#v", wstr),
 			}
 		}
-		for i := range hstr {
-			if hstr[i] != wstr[i] {
+		for i, r := range hrunes {
+			if r != wrunes[i] {
 				return []string{
-					fmt.Sprintf("%s: difference at index %d.", desc, i),
+					fmt.Sprintf("%s: difference at rune %d.", desc, i),
 					fmt.Sprintf("  have: %#v", hstr),
 					fmt.Sprintf("  want: %#v", wstr),
 				}
@@ -446,6 +452,5 @@ func (t *T) deepEqual(
 		}
 	}
 
-	// This shouldn't ever be reached.
 	return diffs
 }

--- a/equal_test.go
+++ b/equal_test.go
@@ -175,6 +175,11 @@ func TestT_EqualAndNotEqual(t *testing.T) {
 			[]interface{}{"", d1, d2, d3})
 	}
 
+	// Unicode strings + Regressions
+	runTest(
+		[]interface{}{"└"},
+		[]interface{}{"╰"})
+
 	// Boolean (no need to test with 100 values.)
 	runTest(
 		[]interface{}{true},


### PR DESCRIPTION
Unicode characters were broken as it would only compare the last byte of
the character due to the strange way that string indexing works in
golang. This converts that to a working rune iteration which is far
safer and catches errors.

A regression test was added in order to test for this case in the
future.